### PR TITLE
add '@' escape

### DIFF
--- a/src/main/groovy/com/orctom/gradle/archetype/util/FileUtils.groovy
+++ b/src/main/groovy/com/orctom/gradle/archetype/util/FileUtils.groovy
@@ -140,9 +140,11 @@ class FileUtils {
 
   static String resolve(String text, Map binding) {
     String escaped = text.replaceAll('\\$', '__DOLLAR__')
+    escaped = escaped.replaceAll('@@', '__AT__')
     String ready = escaped.replaceAll('@([^{}/\\\\@\\n,]+)@', '\\$\\{$1\\}')
     String resolved = engine.createTemplate(ready).make(binding)
     resolved.replaceAll('__DOLLAR__', '\\$')
+    resolved.replaceAll('__AT__', '@')
   }
 
   // Applies variable substitution to provided path.


### PR DESCRIPTION
add `@` escape with `@@`

Fixed a situation like this
```java
@ServiceInterface  (id = "@abbr.toUpperCase()@:@serviceName@Service")
```
