### PR TITLE
Inject prompted values into actual binding

### DIFF
--- a/src/main/groovy/com/orctom/gradle/archetype/ArchetypeGenerateTask.groovy
+++ b/src/main/groovy/com/orctom/gradle/archetype/ArchetypeGenerateTask.groovy
@@ -47,7 +47,9 @@ class ArchetypeGenerateTask extends DefaultTask {
         'project.version': projectVersion
     ]
 
-    bindingsToPrompt.each{ key, defaultValue -> this.class.getParam(key, "Please enter " + key, defaultValue) }
+    binding << bindingsToPrompt.collectEntries { key, defaultValue -> 
+      [ (key): this.class.getParam(key, "Please enter ${key}", defaultValue) ]
+    }
 
     extendedBinding(binding)
 


### PR DESCRIPTION
bindingsToPrompt entries needs to be injected inside the binding map

This is a fix for the ticket https://github.com/orctom/gradle-archetype-plugin/issues/35