### PR TITLE
Add @Internal gradle annotations to tasks to support Gradle 7+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,12 +2,12 @@ plugins {
   id "com.gradle.plugin-publish" version "0.9.7"
 }
 plugins {
-  id 'net.researchgate.release' version '2.3.4'
+  id 'net.researchgate.release' version '2.8.1'
 }
 
 apply plugin: 'groovy'
 apply plugin: 'java-gradle-plugin'
-apply plugin: 'maven'
+apply plugin: 'maven-publish'
 apply plugin: 'idea'
 
 repositories {
@@ -17,8 +17,8 @@ repositories {
 }
 
 dependencies {
-  compile gradleApi()
-  compile localGroovy()
+  implementation gradleApi()
+  implementation localGroovy()
 }
 
 pluginBundle {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip

--- a/src/main/groovy/com/orctom/gradle/archetype/ArchetypeCleanTask.groovy
+++ b/src/main/groovy/com/orctom/gradle/archetype/ArchetypeCleanTask.groovy
@@ -4,6 +4,7 @@ import com.orctom.gradle.archetype.util.FileUtils
 import org.gradle.api.DefaultTask
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 
 import static com.orctom.gradle.archetype.ArchetypePlugin.DIR_TARGET
@@ -25,11 +26,13 @@ class ArchetypeCleanTask extends DefaultTask {
   }
 
   @Override
+  @Internal
   String getGroup() {
     'Archetype'
   }
 
   @Override
+  @Internal
   String getDescription() {
     'Cleans generated project(s)'
   }

--- a/src/main/groovy/com/orctom/gradle/archetype/ArchetypeGenerateTask.groovy
+++ b/src/main/groovy/com/orctom/gradle/archetype/ArchetypeGenerateTask.groovy
@@ -5,6 +5,7 @@ import com.orctom.gradle.archetype.util.FileUtils
 import org.gradle.api.DefaultTask
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 
 import java.util.regex.Pattern
@@ -146,11 +147,13 @@ class ArchetypeGenerateTask extends DefaultTask {
   }
 
   @Override
+  @Internal
   String getGroup() {
     'Archetype'
   }
 
   @Override
+  @Internal
   String getDescription() {
     'Generates project(s) from template(s)'
   }

--- a/src/test/resources/sample/build.gradle
+++ b/src/test/resources/sample/build.gradle
@@ -3,7 +3,7 @@ buildscript {
     mavenLocal()
   }
   dependencies {
-    classpath 'com.orctom.gradle:gradle-archetype-plugin:1.4.6-SNAPSHOT'
+    classpath 'com.orctom.gradle:gradle-archetype-plugin:1.4.9-SNAPSHOT'
   }
 }
 

--- a/src/test/resources/sample/gradle/wrapper/gradle-wrapper.properties
+++ b/src/test/resources/sample/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip


### PR DESCRIPTION
Fixes https://github.com/orctom/gradle-archetype-plugin/issues/41

Things done in this PR:

 * Update the `net.researchgate.release` plugin as it was out of date and throwing an error
 * Replace the old `maven` plugin with the new `maven-publish` plugin, [as the upgrade guide suggests](https://docs.gradle.org/7.0/userguide/upgrading_version_6.html#removal_of_the_legacy_maven_plugin)
 * Update Gradle to the latest (7.2)
 * Add @Internal annotations to the Group & Description getters in the tasks so that Gradle doesn't complain (here are the docs of [@Internal](https://docs.gradle.org/current/javadoc/org/gradle/api/tasks/Internal.html))